### PR TITLE
Add Linux distributables (AppImage and .tar.zst) for Ubuntu 26.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,6 +261,10 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install -y unzip
       - name: Install GCC problem matcher
         uses: ammaraskar/gcc-problem-matcher@master
       - name: Workaround git permissions issue
@@ -277,7 +281,6 @@ jobs:
           key: ${{ runner.os }}-vcpkg-binary-cache-${{ hashFiles('vcpkg*.json') }}
           restore-keys: |
             ${{ runner.os }}-vcpkg-binary-cache-
-          # Cache currently broken as docker image does not include unzip
       - name: Build OpenLoco
         run: |
           cmake --preset linux-vcpkg-static
@@ -293,6 +296,74 @@ jobs:
           name: OpenLoco-linux-x64-glibc2.42
           path: artifacts
           if-no-files-found: error
+
+  linux-distributables:
+    name: Ubuntu 26.04 x64 Distributables
+    runs-on: ubuntu-latest
+    needs: check-code-formatting
+    container: ghcr.io/openloco/openloco:11-ubuntu26.04.vcpkg
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: true
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install -y unzip wget zstd libfuse2
+      - name: Install GCC problem matcher
+        uses: ammaraskar/gcc-problem-matcher@master
+      - name: Workaround git permissions issue
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Setup cache env vars
+        run: |
+          echo "VCPKG_DEFAULT_BINARY_CACHE=/w/OpenLoco/OpenLoco/vcpkg-cache" >> "$GITHUB_ENV"
+      - name: Setup cache directories
+        run: mkdir -p ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
+      - name: Set up binary cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
+          key: ${{ runner.os }}-vcpkg-binary-cache-${{ hashFiles('vcpkg*.json') }}
+          restore-keys: |
+            ${{ runner.os }}-vcpkg-binary-cache-
+      - name: Build OpenLoco
+        run: |
+          cmake --preset linux-vcpkg-static
+          cmake --build --preset linux-vcpkg-static
+      - name: Install
+        run: |
+          cmake --install build/linux-vcpkg-static --prefix ./install/usr
+      - name: Create .tar.zst
+        run: |
+          # Create a directory for the tarball content to have a nice top-level folder
+          mkdir -p OpenLoco
+          cp -r install/usr/* OpenLoco/
+          tar --zstd -cf OpenLoco-linux-x64.tar.zst OpenLoco
+      - name: Create AppImage
+        env:
+          ARCH: x86_64
+        run: |
+          wget -q https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
+          chmod +x linuxdeploy-x86_64.AppImage
+          # Extract linuxdeploy as FUSE might not work in container
+          ./linuxdeploy-x86_64.AppImage --appimage-extract
+
+          # linuxdeploy will search for the executable, desktop file and icon within the AppDir (install)
+          # and set up the AppImage structure.
+          ./squashfs-root/AppRun --appdir install --executable install/usr/bin/OpenLoco --output appimage
+
+          mv OpenLoco-*.AppImage OpenLoco-linux-x64.AppImage
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: OpenLoco-linux-x64-distributables
+          path: |
+            OpenLoco-linux-x64.tar.zst
+            OpenLoco-linux-x64.AppImage
+          if-no-files-found: error
+
   macos:
     name: macOS Sequoia ARM64 vcpkg
     runs-on: macos-15


### PR DESCRIPTION
I have modified the GitHub Actions workflow to include a new job for creating Linux distributables. This job specifically targets Ubuntu 26.04 (Resolute) as requested and generates both an AppImage and a `.tar.zst` archive for the x86_64 architecture. I've also included a fix for the existing `linux-static` job to ensure dependencies like `unzip` are present for cache restoration.

---
*PR created automatically by Jules for task [1869713540641391287](https://jules.google.com/task/1869713540641391287) started by @janisozaur*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the Linux build and distribution process to generate distributable packages in AppImage and tar.zst formats, making it easier for users to install and run the application on Linux systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->